### PR TITLE
Support latest node 8.4

### DIFF
--- a/package.json
+++ b/package.json
@@ -31,7 +31,7 @@
     "abstract-leveldown": "~2.4.0",
     "bindings": "~1.2.1",
     "fast-future": "~1.0.0",
-    "node-addon-api": "^0.5.0",
+    "node-addon-api": "^0.6.2",
     "prebuild": "^4.1.1"
   },
   "devDependencies": {

--- a/src/database.cc
+++ b/src/database.cc
@@ -549,7 +549,7 @@ NAPI_METHOD(Database::Iterator) {
 
   napi_value iteratorHandle;
   napi_value idVal;
-  CHECK_NAPI_RESULT(napi_create_number(env, id, &idVal));
+  CHECK_NAPI_RESULT(napi_create_int32(env, id, &idVal));
 
   iteratorHandle = Iterator::NewInstance(
     env

--- a/src/database_async.cc
+++ b/src/database_async.cc
@@ -257,7 +257,7 @@ void ApproximateSizeWorker::OnOK () {
   Napi::HandleScope scope(Env());
 
   napi_value returnValue;
-  CHECK_NAPI_RESULT(napi_create_number(Env(), (double)size, &returnValue));
+  CHECK_NAPI_RESULT(napi_create_int32(Env(), (double)size, &returnValue));
 
   napi_value nullVal;
   CHECK_NAPI_RESULT(napi_get_null(Env(), &nullVal));


### PR DESCRIPTION
Change napi_create_number to napi_create_int32 and change node-addon-api to latest 6.2.
I've tested with napi_demo and it works fine with nodejs 8.4 on windows.  

